### PR TITLE
Fix hang when compiled with gcc >= 5.1.0

### DIFF
--- a/clk.h
+++ b/clk.h
@@ -51,7 +51,7 @@ typedef struct {
 #define CM_PWM_DIV_PASSWD                        (0x5a << 24)
 #define CM_PWM_DIV_DIVI(val)                     ((val & 0xfff) << 12)
 #define CM_PWM_DIV_DIVF(val)                     ((val & 0xfff) << 0)
-} __attribute__ ((packed)) cm_pwm_t;
+} cm_pwm_t;
 
 
 #define CM_PWM_OFFSET                            (0x001010a0)

--- a/dma.h
+++ b/dma.h
@@ -46,7 +46,7 @@ typedef struct
     uint32_t stride;
     uint32_t nextconbk;
     uint32_t resvd_0x18[2];
-} __attribute__((packed)) dma_cb_t;
+} dma_cb_t;
 
 /*
  * DMA register set
@@ -95,7 +95,7 @@ typedef struct
 #define RPI_DMA_STRIDE_S_STRIDE(val)             ((val & 0xffff) << 0)
     uint32_t nextconbk;
     uint32_t debug;
-} __attribute__((packed)) dma_t;
+} dma_t;
 
 
 #define DMA0_OFFSET                              (0x00007000)

--- a/gpio.h
+++ b/gpio.h
@@ -59,7 +59,7 @@ typedef struct
     uint32_t pudclk[2];                          // GPIO Pin Pull up/down Enable Clock
     uint32_t resvd_0xa0[4];
     uint32_t test;
-} __attribute__((packed)) gpio_t;
+} gpio_t;
 
 
 #define GPIO_OFFSET                              (0x00200000)

--- a/pwm.h
+++ b/pwm.h
@@ -96,7 +96,7 @@ typedef struct
     uint32_t resvd_0x1c;
     uint32_t rng2;
     uint32_t dat2;
-} __attribute__((packed)) pwm_t;
+} pwm_t;
 
 
 #define PWM_OFFSET                               (0x0020c000)


### PR DESCRIPTION
Control registers for DMA, PWM etc. are accessed
via memory-mapped IO. The structs which overlay the
m'mapped regions use **attribute** ((packed)) to ensure
that there are no gaps between the structs fields.

GCC < 5.1.0 assembles the write operation to a int32_t
field inside a **attribute** ((packed))'ed struct
in the form
    str (write single 32-bit value to memory)
whereas GCC >= 5.1.0 does something like
    strb b0 (write byte 0 of 32-bit value)
    strb b1 (write byte 1 of 32-bit value)
    strb b2 (...)
    strb b3 (...)

The BCM2835's Clock Manager General Purpose Clock Control
and Clock Manager General Purpose Clock Divisor Registers
(both inside cm_pwm_t) only accept writes if bits 24-31
contain the value 0x5a, which obviously won't work if
the 32 bits aren't written at once.

As the struct already only contains 32-bit wide fields,
packing them should not be necessary.

For the sake of convenience, I also removed the attribute
from the other m'mapped structs.
